### PR TITLE
feat(js): simplify ESLint configuration

### DIFF
--- a/HOME/.eslintrc.js
+++ b/HOME/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['ybiquitous'],
-}
+  extends: ["eslint:recommended"]
+};

--- a/install/npm.sh
+++ b/install/npm.sh
@@ -13,7 +13,6 @@ $NPM_INSTALL \
   alex \
   emoj \
   eslint \
-  eslint-config-ybiquitous \
   fs-extra \
   markdownlint-cli \
   marked \


### PR DESCRIPTION
What?
-----

* Remove the `eslint-config-ybiquitous` package.
* Change to the `eslint:recommended` configuration.

Why?
----

When using globally installed ESLint, I usually write a temporary JavaScript file,
and in such case, strict linting is not needed.
If needing strict linting, then I usually will create a new project and install ESLint and its plugins locally.

Thus, I decide that the globally installed ESLint should have only the minimum settings.