### PR TITLE
feat(zsh)!: uninstall zsh-completions

### DIFF
--- a/HOME/.zshrc
+++ b/HOME/.zshrc
@@ -99,7 +99,6 @@ plugins=(
   # custom
   zsh-abbr
   zsh-autosuggestions
-  zsh-completions
 )
 
 source $ZSH/oh-my-zsh.sh

--- a/install/oh-my-zsh.sh
+++ b/install/oh-my-zsh.sh
@@ -16,7 +16,6 @@ echo '> Installing custom plugins...'
 (
   cd "${dest}/custom/plugins"
   git_clone https://github.com/zsh-users/zsh-autosuggestions.git
-  git_clone https://github.com/zsh-users/zsh-completions.git
   git_clone https://github.com/olets/zsh-abbr.git
 )
 


### PR DESCRIPTION
Downsides:
- Slow Zsh startup time due to the large number of completions.
- Potential zcompdump conflicts with other built-in completions.

Honestly, I don't need so many completions in this LLM era.

To completely uninstall it, run:

```shell
rm -rf ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-completions
```

Ref: https://github.com/zsh-users/zsh-completions
