### PR TITLE
feat(github): replace `gh` aliases with zsh-abbr

### DIFF
--- a/HOME/.config/gh/config.yml
+++ b/HOME/.config/gh/config.yml
@@ -6,18 +6,4 @@ editor:
 prompt: enabled
 # A pager program to send command output to, e.g. "less". Set the value to "cat" to disable the pager.
 pager: !!null delta --line-numbers
-# Aliases allow you to create nicknames for gh commands
-aliases:
-  open: browse
-  open-actions: browse --actions
-  open-releases: browse --releases
-  open-settings: browse --settings
-  prs: pr list
-  prsme: pr list --author '@me'
-  prv: pr view --web
-  prd: pr diff
-  issues: issue list
-  issuesme: issue list --assignee '@me'
-  aliases: alias list
-  prtitle: pr view --json title --jq .title
 version: "1"

--- a/HOME/.config/zsh-abbr/user-abbreviations
+++ b/HOME/.config/zsh-abbr/user-abbreviations
@@ -53,6 +53,14 @@ abbr "gundo"="git reset HEAD~1"
 abbr "gv"="git show --pretty=full --show-signature"
 abbr "gwip"="git commit --no-verify --message 'chore: wip'"
 
+# gh
+abbr "ghb"="gh browse"
+abbr "ghprc"="gh pr create"
+abbr "ghprl"="gh pr list"
+abbr "ghprv"="gh pr view"
+abbr "ghprd"="gh pr diff"
+abbr "ghisl"="gh issue list"
+
 # rg
 abbr "rg"="rg --no-heading --hidden"
 


### PR DESCRIPTION
Migrate `gh` CLI aliases to zsh-abbr for consistency with git abbreviations.