### PR TITLE
feat(deps): disable Dependency Dashboard by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
     "config:base",
     ":preserveSemverRanges",
     ":maintainLockFilesMonthly",
-    ":automergeMinor"
+    ":automergeMinor",
+    ":disableDependencyDashboard"
   ]
 }


### PR DESCRIPTION
I don't need the dashboard. The open issue #245 often confuses me.

- #245

Ref: https://docs.renovatebot.com/key-concepts/dashboard/#how-to-disable-the-dashboard